### PR TITLE
add common cases for dates

### DIFF
--- a/Network/HTTP/Date/Parser.hs
+++ b/Network/HTTP/Date/Parser.hs
@@ -31,7 +31,7 @@ rfc1123Date = do
     sp
     (h,n,s) <- time
     sp
-    void $ string "GMT"
+    void $ string "GMT" <|> string "+0000" <|> string "UTC"
     return $ defaultHTTPDate {
         hdYear   = y
       , hdMonth  = m

--- a/Network/HTTP/Date/Parser.hs
+++ b/Network/HTTP/Date/Parser.hs
@@ -31,6 +31,8 @@ rfc1123Date = do
     sp
     (h,n,s) <- time
     sp
+    -- RFC 2616 defines GMT only but there are actually ill-formed ones such 
+    -- as "+0000" and "UTC" in the wild.
     void $ string "GMT" <|> string "+0000" <|> string "UTC"
     return $ defaultHTTPDate {
         hdYear   = y


### PR DESCRIPTION
Hi Kazu - I checked about 26 thousand sites I had on hand, and all had either +0000, UTC or GMT for dates, so this might be a good stopgap before doing proper timezone parsing?

(7k each for UTC and +0000 - your GMT only handled 117 of my sample)