### PR TITLE
Prevent incorrect HTTP date conversion

### DIFF
--- a/Network/HTTP/Date/Converter.hs
+++ b/Network/HTTP/Date/Converter.hs
@@ -63,7 +63,7 @@ utcToHTTPDate x = defaultHTTPDate {
   , hdDay    = d
   , hdHour   = h
   , hdMinute = n
-  , hdSecond = round s
+  , hdSecond = truncate s
   , hdWkday  = fromEnum (w :: Int)
   }
   where


### PR DESCRIPTION
When seconds equals to something like 59.999 round produces 60 instead
of 59. The resulting string is okay for http-date parser but is rejected
by other implementations.