### PR TITLE
http-date.cabal: make sure to include hspec-discover as build tool

### DIFF
--- a/http-date.cabal
+++ b/http-date.cabal
@@ -31,6 +31,7 @@ Test-Suite spec
   Main-Is:              Spec.hs
   Other-Modules:        DateSpec
                         Model
+  Build-Tool-Depends:   hspec-discover:hspec-discover
   Build-Depends:        base >= 4.9 && < 5
                       , bytestring
                       , hspec


### PR DESCRIPTION
It is technically required to run the tests.